### PR TITLE
Delay any rejection response to avoid brute forcing

### DIFF
--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -111,14 +111,14 @@ class SFTPS3Server extends EventEmitter {
       });
       client.on('authentication', (ctx) => {
         if(ctx.method !== 'publickey') {
-            setTimeout((ctx) => { ctx.reject(['publickey']) }, 5000);
-            return;
+          setTimeout(() => { ctx.reject(['publickey']) }, 5000);
+          return;
         }
 
         pubKey = this._findKey(ctx.username, ctx.key);
         if(!pubKey) {
           this._log('public key not found');
-          setTimeout((ctx) => { ctx.reject(['publickey not found']) }, 5000);
+          setTimeout(() => { ctx.reject(['publickey not found']) }, 5000);
           return;
         }
 
@@ -131,7 +131,7 @@ class SFTPS3Server extends EventEmitter {
           }
           else {
             this._log('signature rejected');
-            setTimeout((ctx) => { ctx.reject() }, 5000);
+            setTimeout(() => { ctx.reject() }, 5000);
             return;
           }
         }

--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -111,13 +111,15 @@ class SFTPS3Server extends EventEmitter {
       });
       client.on('authentication', (ctx) => {
         if(ctx.method !== 'publickey') {
-          return ctx.reject(['publickey']);
+            setTimeout((ctx) => { ctx.reject(['publickey']) }, 5000);
+            return;
         }
 
         pubKey = this._findKey(ctx.username, ctx.key);
         if(!pubKey) {
           this._log('public key not found');
-          return ctx.reject(['publickey not found']);
+          setTimeout((ctx) => { ctx.reject(['publickey not found']) }, 5000);
+          return;
         }
 
         if(ctx.signature) {
@@ -129,7 +131,8 @@ class SFTPS3Server extends EventEmitter {
           }
           else {
             this._log('signature rejected');
-            return ctx.reject();
+            setTimeout((ctx) => { ctx.reject() }, 5000);
+            return;
           }
         }
         else {
@@ -540,6 +543,8 @@ class SFTPS3Server extends EventEmitter {
 
       });
     });
+
+    this.ssh.maxConnections = 5;
 
     this.ssh.listen(port, bindAddress, function() {
       if(callback)


### PR DESCRIPTION
This PR is admittedly a bit of a hack right now, but it's what I needed on my side.  Let me know if there's interest and I can clean it up and make things configurable.

Running node-sftp-s3 on AWS, I was receiving 15 connection attempts per second from a bot trying to brute-force an SSH password.  Since only public-key authentication is supported, that was never going to happen, but he quickly filled up my disks with failure logs.

This PR adds a 5 second delay before any rejection is reported, and limits the total number of connections to the server to 5.

Obviously exponential backoff, IP banning, etc., are better approaches, but this will make an attackers ability to chug through a password list (uselessly) 75 times slower.